### PR TITLE
fix: rbac configmaps

### DIFF
--- a/chart/swagger-hub-controller/templates/clusterrole.yaml
+++ b/chart/swagger-hub-controller/templates/clusterrole.yaml
@@ -46,6 +46,7 @@ rules:
   resources:
   - events
   - services
+  - configmaps
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
+  - configmaps
   - services
   verbs:
   - delete
@@ -22,6 +16,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/internal/controllers/swaggerhub_controller.go
+++ b/internal/controllers/swaggerhub_controller.go
@@ -51,6 +51,7 @@ import (
 // +kubebuilder:rbac:groups=apps,resources=namespaces,verbs=get;watch;list
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;update;patch;delete;watch;list
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;update;patch;delete;watch;list
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;update;patch;delete;watch;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SwaggerHub reconciles a SwaggerHub object


### PR DESCRIPTION
## Current situation
The charts bundles a ClusterRole with insufficient permissions for dealing with configmaps.

## Proposal
Fix rbac.
