### PR TITLE
feat(chart): support custom CA bundles for HTTPS requests

### DIFF
--- a/chart/swagger-hub-controller/templates/deployment.yaml
+++ b/chart/swagger-hub-controller/templates/deployment.yaml
@@ -79,6 +79,13 @@ spec:
           subPath: {{ .subPath }}
           {{- end }}
         {{- end }}
+        {{- range .Values.configMapMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .path }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.kubeRBACProxy.enabled }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
@@ -107,6 +114,11 @@ spec:
       - name: {{ .name }}
         secret:
           secretName: {{ .secretName }}
+      {{- end }}
+      {{- range .Values.configMapMounts }}
+      - name: {{ .name }}
+        configMap:
+          name: {{ .configMapName }}
       {{- end }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/chart/swagger-hub-controller/values.yaml
+++ b/chart/swagger-hub-controller/values.yaml
@@ -29,6 +29,22 @@ secretMounts: []
 #    secretName: secret
 #    path: /secrets
 
+# A list of configmaps and their paths to mount inside the pod.
+# This is useful for mounting a custom CA bundle to be trusted for outgoing
+# https requests (e.g. when fetching SwaggerDefinitions served with a
+# certificate signed by a private/internal CA).
+#
+# Combine this with `env.SSL_CERT_FILE` (see below) to make Go's default
+# HTTPS transport trust the mounted bundle. A common source for such a
+# bundle is a `Bundle` resource managed by trust-manager
+# (https://cert-manager.io/docs/trust/trust-manager/, part of the
+# CNCF/Linux Foundation cert-manager project), which can render the trusted
+# CA certificates of a cluster into a ConfigMap.
+configMapMounts: []
+#  - name: trust-bundle
+#    configMapName: trust-bundle
+#    path: /etc/ssl/custom-certs
+
 # Add additional containers (sidecars)
 extraContainers:
 
@@ -66,6 +82,12 @@ env: {}
 # env:
 #   NAMESPACES: default
 #   CONCURRENT: "10"
+#   # Trust a custom CA bundle mounted via `configMapMounts` for all outgoing
+#   # https requests (Go reads SSL_CERT_FILE on Linux, see
+#   # https://pkg.go.dev/crypto/x509#SystemCertPool). The referenced file
+#   # must contain the full set of trusted CA certificates, not just the
+#   # custom one, since it replaces rather than extends the system roots.
+#   SSL_CERT_FILE: /etc/ssl/custom-certs/ca-bundle.pem
 
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc


### PR DESCRIPTION
Add ConfigMap mounts and environment variable injection to the controller Deployment, allowing a trust bundle emitted by cert-manager trust-manager to be mounted and selected via SSL_CERT_FILE.

This enables Go's default HTTPS transport to validate Swagger definitions signed by private or internal CAs without per-definition TLS configuration.

See https://cert-manager.io/docs/trust/trust-manager/


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ConfigMap mounts to the controller chart so custom CA bundles can be trusted for outgoing HTTPS requests, allowing Swagger definitions signed by private or internal CAs to be fetched without per-definition TLS config.

**New Features**
- New `configMapMounts` value mounts ConfigMaps as volumes in the controller Deployment.
- Pair it with `env.SSL_CERT_FILE` to make Go's default HTTPS transport trust the mounted bundle, such as one produced by cert-manager trust-manager.
- `SSL_CERT_FILE` replaces rather than extends system roots, so the bundle must include all trusted CAs.

<sup>Written for commit 3f6eee3a4dadb3dbd2b81ad898930f009d9afa8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/swagger-hub-controller/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

