### PR TITLE
fix: preserve security schemes in merged OpenAPI specs

### DIFF
--- a/internal/controllers/swaggerspecification_controller.go
+++ b/internal/controllers/swaggerspecification_controller.go
@@ -265,6 +265,7 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 
 	var paths []openapi3.NewPathsOption
 	var components = make(openapi3.Schemas)
+	var securitySchemes = make(openapi3.SecuritySchemes)
 
 	for result := range results {
 		if result.err != nil {
@@ -275,6 +276,10 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 		if result.spec.Components != nil {
 			for name, schema := range result.spec.Components.Schemas {
 				components[name] = schema
+			}
+
+			for name, scheme := range result.spec.Components.SecuritySchemes {
+				securitySchemes[name] = scheme
 			}
 		}
 
@@ -296,7 +301,8 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 
 	schema.Paths = openapi3.NewPaths(paths...)
 	schema.Components = &openapi3.Components{
-		Schemas: components,
+		Schemas:         components,
+		SecuritySchemes: securitySchemes,
 	}
 
 	return specification, schema, nil


### PR DESCRIPTION
Pass through components.securitySchemes when merging Swagger definitions so Swagger UI exposes the Authorize button.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes merged OpenAPI specs dropping `securitySchemes`, so Swagger UI now exposes the Authorize button as it did before.

Previously, only schemas were merged across Swagger definitions, leaving the merged spec without security schemes. Now security schemes are copied alongside schemas during the merge.

<sup>Written for commit 50dee21aa7f2c51cdbb62dd7b35caa41f1f19243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/swagger-hub-controller/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

