### PR TITLE
feat: prefix tags per definition name in merged OpenAPI spec

### DIFF
--- a/internal/controllers/swaggerspecification_controller.go
+++ b/internal/controllers/swaggerspecification_controller.go
@@ -47,6 +47,8 @@ import (
 	infrav1beta1 "github.com/DoodleScheduling/swagger-hub-controller/api/v1beta1"
 )
 
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+
 // SwaggerSpecification reconciles a SwaggerSpecification object
 type SwaggerSpecificationReconciler struct {
 	client.Client
@@ -198,7 +200,7 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 
 			untypedSpec := make(map[string]interface{})
 
-			err := r.fetchDefinition(ctx, *definition.Spec.URL, &untypedSpec)
+			err := r.fetchDefinition(ctx, definition, &untypedSpec)
 			if err != nil {
 				results <- fetchResult{
 					definition: &definition,
@@ -265,6 +267,8 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 
 	var paths []openapi3.NewPathsOption
 	var components = make(openapi3.Schemas)
+	var securitySchemes = make(openapi3.SecuritySchemes)
+	var tags openapi3.Tags
 
 	for result := range results {
 		if result.err != nil {
@@ -276,11 +280,32 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 			for name, schema := range result.spec.Components.Schemas {
 				components[name] = schema
 			}
+
+			for name, scheme := range result.spec.Components.SecuritySchemes {
+				securitySchemes[name] = scheme
+			}
+		}
+
+		for _, tag := range result.spec.Tags {
+			tags = append(tags, &openapi3.Tag{
+				Name:         fmt.Sprintf("%s.%s", result.definition.Name, tag.Name),
+				Description:  tag.Description,
+				ExternalDocs: tag.ExternalDocs,
+			})
 		}
 
 		for _, pathItem := range result.spec.Paths.Map() {
 			for _, op := range pathItem.Operations() {
-				op.Tags = []string{result.definition.Name}
+				if len(op.Tags) == 0 {
+					op.Tags = []string{result.definition.Name}
+					continue
+				}
+
+				prefixedTags := make([]string, len(op.Tags))
+				for i, tag := range op.Tags {
+					prefixedTags[i] = fmt.Sprintf("%s.%s", result.definition.Name, tag)
+				}
+				op.Tags = prefixedTags
 			}
 		}
 
@@ -296,18 +321,24 @@ func (r *SwaggerSpecificationReconciler) generateOpenAPI(ctx context.Context, sp
 
 	schema.Paths = openapi3.NewPaths(paths...)
 	schema.Components = &openapi3.Components{
-		Schemas: components,
+		Schemas:         components,
+		SecuritySchemes: securitySchemes,
 	}
+	schema.Tags = tags
 
 	return specification, schema, nil
 }
 
-func (r *SwaggerSpecificationReconciler) fetchDefinition(ctx context.Context, url string, to interface{}) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func (r *SwaggerSpecificationReconciler) fetchDefinition(ctx context.Context, definition infrav1beta1.SwaggerDefinition, to interface{}) error {
+	req, err := http.NewRequest(http.MethodGet, *definition.Spec.URL, nil)
 	if err != nil {
 		return fmt.Errorf("create request failed: %w", err)
 	}
 	req = req.WithContext(ctx)
+
+	if err := r.authenticateRequest(ctx, definition, req); err != nil {
+		return err
+	}
 
 	res, err := r.HTTPClient.Do(req)
 	if err != nil {
@@ -320,6 +351,10 @@ func (r *SwaggerSpecificationReconciler) fetchDefinition(ctx context.Context, ur
 		}()
 	}
 
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return fmt.Errorf("unexpected http status code %d", res.StatusCode)
+	}
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("read response body failed: %w", err)
@@ -329,6 +364,46 @@ func (r *SwaggerSpecificationReconciler) fetchDefinition(ctx context.Context, ur
 	if err != nil {
 		return fmt.Errorf("decode response body failed: %w", err)
 	}
+
+	return nil
+}
+
+// authenticateRequest adds the credentials referenced by the SwaggerDefinition to the request.
+func (r *SwaggerSpecificationReconciler) authenticateRequest(ctx context.Context, definition infrav1beta1.SwaggerDefinition, req *http.Request) error {
+	if definition.Spec.Auth == nil || definition.Spec.Auth.Basic == nil {
+		return nil
+	}
+
+	basic := definition.Spec.Auth.Basic
+	if req.URL.Scheme != "https" && !basic.AllowInsecure {
+		return fmt.Errorf("refusing to send basic auth credentials to an insecure %s:// url", req.URL.Scheme)
+	}
+
+	secretRef := basic.SecretRef
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{Namespace: definition.Namespace, Name: secretRef.Name}, &secret); err != nil {
+		return fmt.Errorf("failed to get referenced secret %s: %w", secretRef.Name, err)
+	}
+
+	usernameField := cmp.Or(secretRef.UsernameField, "username")
+	passwordField := cmp.Or(secretRef.PasswordField, "password")
+
+	username := basic.Username
+	if username == "" {
+		v, ok := secret.Data[usernameField]
+		if !ok {
+			return fmt.Errorf("field %s not found in secret %s", usernameField, secretRef.Name)
+		}
+
+		username = string(v)
+	}
+
+	password, ok := secret.Data[passwordField]
+	if !ok {
+		return fmt.Errorf("field %s not found in secret %s", passwordField, secretRef.Name)
+	}
+
+	req.SetBasicAuth(username, string(password))
 
 	return nil
 }

--- a/internal/controllers/swaggerspecification_controller_test.go
+++ b/internal/controllers/swaggerspecification_controller_test.go
@@ -2,7 +2,10 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/DoodleScheduling/swagger-hub-controller/api/v1beta1"
@@ -157,6 +160,474 @@ var _ = Describe("SwaggerSpecification controller", func() {
 		It("cleans up", func() {
 			ctx := context.Background()
 			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+		})
+	})
+
+	When("a definition requires basic auth", func() {
+		var (
+			specification *v1beta1.SwaggerSpecification
+			definition    *v1beta1.SwaggerDefinition
+			secret        *corev1.Secret
+			server        *httptest.Server
+			scope         = randStringRunes(5)
+			name          = fmt.Sprintf("basicauth-%s", randStringRunes(5))
+		)
+
+		It("fetches the definition using the credentials from the referenced secret", func() {
+			ctx := context.Background()
+
+			By("serving a definition behind basic auth over https")
+			server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				username, password, ok := r.BasicAuth()
+				if !ok || username != "user" || password != "pass" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"openapi":"3.0.1","info":{"title":"secured","version":"1"},"paths":{"/secured":{"get":{"responses":{"200":{"description":"ok"}}}}}}`))
+			}))
+
+			testHTTPClient.set(server.Client())
+
+			By("creating the credentials secret")
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte("user"),
+					"password": []byte("pass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("creating a SwaggerDefinition referencing the secret")
+			definition = &v1beta1.SwaggerDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels:    map[string]string{"scope": scope},
+				},
+				Spec: v1beta1.SwaggerDefinitionSpec{
+					URL: &server.URL,
+					Auth: &v1beta1.DefinitionAuth{
+						Basic: &v1beta1.BasicAuth{
+							SecretRef: v1beta1.LocalSecretReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, definition)).Should(Succeed())
+
+			specification = &v1beta1.SwaggerSpecification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: v1beta1.SwaggerSpecificationSpec{
+					Info: v1beta1.Info{
+						Title: "secured",
+					},
+					DefinitionSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"scope": scope},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, specification)).Should(Succeed())
+
+			By("waiting for the merged specification")
+			key := types.NamespacedName{Name: fmt.Sprintf("swagger-specification-%s", name), Namespace: "default"}
+			cm := &corev1.ConfigMap{}
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, key, cm); err != nil {
+					return ""
+				}
+
+				return string(cm.BinaryData["specification.json"])
+			}, timeout, interval).Should(ContainSubstring(`"/secured"`))
+
+			reconciledInstance := &v1beta1.SwaggerSpecification{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, reconciledInstance)).Should(Succeed())
+			Expect(reconciledInstance.Status.SubResourceCatalog).Should(HaveLen(1))
+			Expect(reconciledInstance.Status.SubResourceCatalog[0].Error).Should(BeEmpty())
+		})
+
+		It("cleans up", func() {
+			ctx := context.Background()
+			server.Close()
+			testHTTPClient.set(http.DefaultClient)
+			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, definition)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+		})
+	})
+
+	When("a definition with basic auth points to an insecure url", func() {
+		var (
+			specification *v1beta1.SwaggerSpecification
+			definition    *v1beta1.SwaggerDefinition
+			scope         = randStringRunes(5)
+			name          = fmt.Sprintf("insecure-%s", randStringRunes(5))
+			url           = "http://insecure/openapi"
+		)
+
+		It("does not send the credentials and reports an error", func() {
+			ctx := context.Background()
+
+			definition = &v1beta1.SwaggerDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels:    map[string]string{"scope": scope},
+				},
+				Spec: v1beta1.SwaggerDefinitionSpec{
+					URL: &url,
+					Auth: &v1beta1.DefinitionAuth{
+						Basic: &v1beta1.BasicAuth{
+							SecretRef: v1beta1.LocalSecretReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, definition)).Should(Succeed())
+
+			specification = &v1beta1.SwaggerSpecification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: v1beta1.SwaggerSpecificationSpec{
+					Info: v1beta1.Info{
+						Title: "insecure",
+					},
+					DefinitionSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"scope": scope},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, specification)).Should(Succeed())
+
+			instanceLookupKey := types.NamespacedName{Name: name, Namespace: "default"}
+			reconciledInstance := &v1beta1.SwaggerSpecification{}
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, instanceLookupKey, reconciledInstance); err != nil {
+					return ""
+				}
+
+				if len(reconciledInstance.Status.SubResourceCatalog) != 1 {
+					return ""
+				}
+
+				return reconciledInstance.Status.SubResourceCatalog[0].Error
+			}, timeout, interval).Should(ContainSubstring("refusing to send basic auth credentials to an insecure http:// url"))
+		})
+
+		It("cleans up", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, definition)).Should(Succeed())
+		})
+	})
+
+	When("a definition with basic auth allows an insecure url", func() {
+		var (
+			specification *v1beta1.SwaggerSpecification
+			definition    *v1beta1.SwaggerDefinition
+			secret        *corev1.Secret
+			server        *httptest.Server
+			scope         = randStringRunes(5)
+			name          = fmt.Sprintf("allowinsecure-%s", randStringRunes(5))
+		)
+
+		It("sends the credentials over http", func() {
+			ctx := context.Background()
+
+			By("serving a definition behind basic auth over http")
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				username, password, ok := r.BasicAuth()
+				if !ok || username != "user" || password != "pass" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"openapi":"3.0.1","info":{"title":"insecure","version":"1"},"paths":{"/insecure":{"get":{"responses":{"200":{"description":"ok"}}}}}}`))
+			}))
+
+			By("creating the credentials secret")
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte("user"),
+					"password": []byte("pass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			definition = &v1beta1.SwaggerDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels:    map[string]string{"scope": scope},
+				},
+				Spec: v1beta1.SwaggerDefinitionSpec{
+					URL: &server.URL,
+					Auth: &v1beta1.DefinitionAuth{
+						Basic: &v1beta1.BasicAuth{
+							AllowInsecure: true,
+							SecretRef: v1beta1.LocalSecretReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, definition)).Should(Succeed())
+
+			specification = &v1beta1.SwaggerSpecification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: v1beta1.SwaggerSpecificationSpec{
+					Info: v1beta1.Info{
+						Title: "insecure",
+					},
+					DefinitionSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"scope": scope},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, specification)).Should(Succeed())
+
+			By("waiting for the merged specification")
+			key := types.NamespacedName{Name: fmt.Sprintf("swagger-specification-%s", name), Namespace: "default"}
+			cm := &corev1.ConfigMap{}
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, key, cm); err != nil {
+					return ""
+				}
+
+				return string(cm.BinaryData["specification.json"])
+			}, timeout, interval).Should(ContainSubstring(`"/insecure"`))
+		})
+
+		It("cleans up", func() {
+			ctx := context.Background()
+			server.Close()
+			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, definition)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+		})
+	})
+
+	When("a definition with basic auth configures a static username", func() {
+		var (
+			specification *v1beta1.SwaggerSpecification
+			definition    *v1beta1.SwaggerDefinition
+			secret        *corev1.Secret
+			server        *httptest.Server
+			scope         = randStringRunes(5)
+			name          = fmt.Sprintf("staticuser-%s", randStringRunes(5))
+		)
+
+		It("uses the static username and the password from the referenced secret", func() {
+			ctx := context.Background()
+
+			By("serving a definition behind basic auth over https")
+			server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				username, password, ok := r.BasicAuth()
+				if !ok || username != "actuator" || password != "pass" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"openapi":"3.0.1","info":{"title":"static","version":"1"},"paths":{"/static":{"get":{"responses":{"200":{"description":"ok"}}}}}}`))
+			}))
+
+			testHTTPClient.set(server.Client())
+
+			By("creating a secret which only holds the password")
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"password": []byte("pass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			definition = &v1beta1.SwaggerDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels:    map[string]string{"scope": scope},
+				},
+				Spec: v1beta1.SwaggerDefinitionSpec{
+					URL: &server.URL,
+					Auth: &v1beta1.DefinitionAuth{
+						Basic: &v1beta1.BasicAuth{
+							Username: "actuator",
+							SecretRef: v1beta1.LocalSecretReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, definition)).Should(Succeed())
+
+			specification = &v1beta1.SwaggerSpecification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: v1beta1.SwaggerSpecificationSpec{
+					Info: v1beta1.Info{
+						Title: "static",
+					},
+					DefinitionSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"scope": scope},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, specification)).Should(Succeed())
+
+			By("waiting for the merged specification")
+			key := types.NamespacedName{Name: fmt.Sprintf("swagger-specification-%s", name), Namespace: "default"}
+			cm := &corev1.ConfigMap{}
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, key, cm); err != nil {
+					return ""
+				}
+
+				return string(cm.BinaryData["specification.json"])
+			}, timeout, interval).Should(ContainSubstring(`"/static"`))
+		})
+
+		It("cleans up", func() {
+			ctx := context.Background()
+			server.Close()
+			testHTTPClient.set(http.DefaultClient)
+			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, definition)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+		})
+	})
+
+	When("a definition declares tags", func() {
+		var (
+			specification *v1beta1.SwaggerSpecification
+			definition    *v1beta1.SwaggerDefinition
+			server        *httptest.Server
+			scope         = randStringRunes(5)
+			name          = fmt.Sprintf("tagged-%s", randStringRunes(5))
+		)
+
+		It("prefixes tag names and preserves their descriptions", func() {
+			ctx := context.Background()
+
+			By("serving a definition with top-level tags and tagged operations")
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"openapi":"3.0.1",
+					"info":{"title":"tagged","version":"1"},
+					"tags":[{"name":"task-controller","description":"Task operations"}],
+					"paths":{
+						"/tasks":{"get":{"tags":["task-controller"],"responses":{"200":{"description":"ok"}}}},
+						"/untagged":{"get":{"responses":{"200":{"description":"ok"}}}}
+					}
+				}`))
+			}))
+
+			definition = &v1beta1.SwaggerDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels:    map[string]string{"scope": scope},
+				},
+				Spec: v1beta1.SwaggerDefinitionSpec{
+					URL: &server.URL,
+				},
+			}
+			Expect(k8sClient.Create(ctx, definition)).Should(Succeed())
+
+			specification = &v1beta1.SwaggerSpecification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: v1beta1.SwaggerSpecificationSpec{
+					Info: v1beta1.Info{
+						Title: "tagged",
+					},
+					DefinitionSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"scope": scope},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, specification)).Should(Succeed())
+
+			By("waiting for the merged specification")
+			key := types.NamespacedName{Name: fmt.Sprintf("swagger-specification-%s", name), Namespace: "default"}
+			cm := &corev1.ConfigMap{}
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, key, cm); err != nil {
+					return ""
+				}
+
+				return string(cm.BinaryData["specification.json"])
+			}, timeout, interval).Should(ContainSubstring(`"/tasks"`))
+
+			var merged struct {
+				Tags []struct {
+					Name        string `json:"name"`
+					Description string `json:"description"`
+				} `json:"tags"`
+				Paths map[string]struct {
+					Get struct {
+						Tags []string `json:"tags"`
+					} `json:"get"`
+				} `json:"paths"`
+			}
+			Expect(json.Unmarshal(cm.BinaryData["specification.json"], &merged)).Should(Succeed())
+
+			expectedTag := fmt.Sprintf("%s.task-controller", name)
+
+			By("prefixing the top-level tag name while keeping its description")
+			Expect(merged.Tags).Should(ContainElement(HaveField("Name", expectedTag)))
+			Expect(merged.Tags).Should(ContainElement(HaveField("Description", "Task operations")))
+
+			By("prefixing the tag referenced by the tagged operation")
+			Expect(merged.Paths["/tasks"].Get.Tags).Should(ConsistOf(expectedTag))
+
+			By("falling back to the definition name for untagged operations")
+			Expect(merged.Paths["/untagged"].Get.Tags).Should(ConsistOf(name))
+		})
+
+		It("cleans up", func() {
+			ctx := context.Background()
+			server.Close()
+			Expect(k8sClient.Delete(ctx, specification)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, definition)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
When merging multiple SwaggerDefinitions, top-level tags and operation-level tags are now prefixed with the definition name.

This preserves the original Spring Boot controller groupings in Swagger UI while preventing tag name collisions across services. Operations that carry no tags fall back to the definition name, matching the previous behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefixes top-level and operation tags with the definition name in merged OpenAPI specs, and adds basic auth support for fetching definitions.

**New Features**
- Merged specs now use prefixed tags like `definition.tag`; untagged operations keep the definition name as their tag.
- Definitions can reference a `Secret` for basic auth credentials, with an `AllowInsecure` flag to permit HTTP.
- Security schemes from all definitions are now merged into the output.

<sup>Written for commit 536b29155557a3bed83ed81ec79d446f8c495332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/swagger-hub-controller/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

